### PR TITLE
ARM: dts: imx6ull-tarragon: fix USB over-current polarity

### DIFF
--- a/arch/arm/boot/dts/imx6ull-tarragon-common.dtsi
+++ b/arch/arm/boot/dts/imx6ull-tarragon-common.dtsi
@@ -805,6 +805,7 @@
 		     &pinctrl_usb_pwr>;
 	dr_mode = "host";
 	power-active-high;
+	over-current-active-low;
 	disable-over-current;
 	status = "okay";
 };


### PR DESCRIPTION
Our Tarragon platform uses a active-low signal to inform the i.MX6ULL about the over-current detection.