### PR TITLE
ARM: dts: imx6ull-tarragon-common: Disable DMA for both SPI

### DIFF
--- a/arch/arm/boot/dts/imx6ull-tarragon-common.dtsi
+++ b/arch/arm/boot/dts/imx6ull-tarragon-common.dtsi
@@ -97,6 +97,8 @@
 	cs-gpios = <&gpio1 29 GPIO_ACTIVE_HIGH
 		    &gpio3 2  GPIO_ACTIVE_HIGH
 		    &gpio3 4  GPIO_ACTIVE_HIGH>;
+	/delete-property/dmas;
+	/delete-property/dma-names;
 };
 
 &ecspi4 {
@@ -106,6 +108,8 @@
 	pinctrl-0 = <&pinctrl_ecspi4>;
 	num-cs = <1>;
 	cs-gpios = <&gpio2 15 GPIO_ACTIVE_HIGH>;
+	/delete-property/dmas;
+	/delete-property/dma-names;
 };
 
 &fec1 {


### PR DESCRIPTION
Comparing linux-imx 4.9.11 and this branch shows a significant performance gap on the SPI. The vendor branch has DMA disabled, so SPI operates just in PIO mode. A possible reason for this is that the SDMA ROM firmware has issues.

So instead of enabling the SDMA driver with all these consequences, just disable DMA as in the vendor branch.

Parameter:
Poll limit = 30 usec (default)

Before
Mode: Poll + DMA
mains PLC throughput: ~ 2.69 Mbits/sec
mains PLC latency: ~ 5.2 msec

After
Mode: Poll + PIO
mains PLC throughput: ~ 5.00 Mbits/sec
mains PLC latency: ~ 4.5 msec