### PR TITLE
ARM: dts: imx6ull-tarragon: Reduce SPI clock for PLC

### DIFF
--- a/arch/arm/boot/dts/imx6ull-tarragon-master.dts
+++ b/arch/arm/boot/dts/imx6ull-tarragon-master.dts
@@ -45,7 +45,7 @@
 		interrupts = <19 IRQ_TYPE_EDGE_RISING>;
 		spi-cpha;
 		spi-cpol;
-		spi-max-frequency = <16000000>;
+		spi-max-frequency = <12000000>;
 	};
 };
 
@@ -63,7 +63,7 @@
 		interrupts = <9 IRQ_TYPE_EDGE_RISING>;
 		spi-cpha;
 		spi-cpol;
-		spi-max-frequency = <16000000>;
+		spi-max-frequency = <12000000>;
 	};
 };
 

--- a/arch/arm/boot/dts/imx6ull-tarragon-slave.dts
+++ b/arch/arm/boot/dts/imx6ull-tarragon-slave.dts
@@ -23,7 +23,7 @@
 		interrupts = <19 IRQ_TYPE_EDGE_RISING>;
 		spi-cpha;
 		spi-cpol;
-		spi-max-frequency = <16000000>;
+		spi-max-frequency = <12000000>;
 	};
 };
 

--- a/arch/arm/boot/dts/imx6ull-tarragon-slavext.dts
+++ b/arch/arm/boot/dts/imx6ull-tarragon-slavext.dts
@@ -45,7 +45,7 @@
 		interrupts = <19 IRQ_TYPE_EDGE_RISING>;
 		spi-cpha;
 		spi-cpol;
-		spi-max-frequency = <16000000>;
+		spi-max-frequency = <12000000>;
 	};
 };
 


### PR DESCRIPTION
The spi-max-frequency was higher than the specification from Qualcomm. So reduce the frequency limit in order to be conform and try to avoid bit errors.