### PR TITLE
ARM: dts: evacharge/tarragon: Reduce SPI clock for PLC

### DIFF
--- a/arch/arm/boot/dts/imx28-evachargese.dts
+++ b/arch/arm/boot/dts/imx28-evachargese.dts
@@ -55,7 +55,7 @@
 					interrupts = <25 IRQ_TYPE_EDGE_RISING>;
 					spi-cpha;
 					spi-cpol;
-					spi-max-frequency = <16000000>;
+					spi-max-frequency = <12000000>;
 					intr-gpios = <&gpio3 25 GPIO_ACTIVE_HIGH>;
 				};
 

--- a/arch/arm/boot/dts/imx6ull-tarragon-master.dts
+++ b/arch/arm/boot/dts/imx6ull-tarragon-master.dts
@@ -39,7 +39,7 @@
 		interrupts = <19 IRQ_TYPE_EDGE_RISING>;
 		spi-cpha;
 		spi-cpol;
-		spi-max-frequency = <16000000>;
+		spi-max-frequency = <12000000>;
 	};
 };
 
@@ -55,7 +55,7 @@
 		interrupts = <9 IRQ_TYPE_EDGE_RISING>;
 		spi-cpha;
 		spi-cpol;
-		spi-max-frequency = <16000000>;
+		spi-max-frequency = <12000000>;
 	};
 };
 

--- a/arch/arm/boot/dts/imx6ull-tarragon-slave.dts
+++ b/arch/arm/boot/dts/imx6ull-tarragon-slave.dts
@@ -31,7 +31,7 @@
 		interrupts = <19 IRQ_TYPE_EDGE_RISING>;
 		spi-cpha;
 		spi-cpol;
-		spi-max-frequency = <16000000>;
+		spi-max-frequency = <12000000>;
 	};
 };
 

--- a/arch/arm/boot/dts/imx6ull-tarragon-slavext.dts
+++ b/arch/arm/boot/dts/imx6ull-tarragon-slavext.dts
@@ -39,7 +39,7 @@
 		interrupts = <19 IRQ_TYPE_EDGE_RISING>;
 		spi-cpha;
 		spi-cpol;
-		spi-max-frequency = <16000000>;
+		spi-max-frequency = <12000000>;
 	};
 };
 


### PR DESCRIPTION
The spi-max-frequency was higher than the specification from Qualcomm. So reduce the frequency limit in order to be conform and try to avoid bit errors.