### PR TITLE
arm64: dts: imx93-charge-som-dc-evb: switch user led behavior

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx93-charge-som-dc-evb.dts
+++ b/arch/arm64/boot/dts/freescale/imx93-charge-som-dc-evb.dts
@@ -93,9 +93,9 @@
 		
 		USER_RED {
 			color = <LED_COLOR_ID_RED>;
-			function = LED_FUNCTION_HEARTBEAT;
+			function = LED_FUNCTION_BOOT;
 			gpios = <&gpio2 24 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "heartbeat";
+			linux,default-trigger = "timer";
 		};
 	};
 


### PR DESCRIPTION
The idea is to have a different behavior during the boot phase and the remaining runtime.
So let's use the default timer as initial trigger and express this slightly changed behavior by switching function from 'heartbeat' to 'boot'.