### PR TITLE
[RFC] net: vertexcom: mse102x: Fix SPI interrupt handling

### DIFF
--- a/Documentation/devicetree/bindings/net/vertexcom-mse102x.yaml
+++ b/Documentation/devicetree/bindings/net/vertexcom-mse102x.yaml
@@ -63,7 +63,7 @@ examples:
             compatible = "vertexcom,mse1021";
             reg = <0>;
             interrupt-parent = <&gpio>;
-            interrupts = <23 IRQ_TYPE_EDGE_RISING>;
+            interrupts = <23 IRQ_TYPE_LEVEL_HIGH>;
             spi-cpha;
             spi-cpol;
             spi-max-frequency = <7142857>;

--- a/arch/arm64/boot/dts/freescale/imx93-charge-som.dtsi
+++ b/arch/arm64/boot/dts/freescale/imx93-charge-som.dtsi
@@ -98,8 +98,7 @@
 	ethernet@0 {
 		compatible = "vertexcom,mse1021";
 		reg = <0>;
-		interrupt-parent = <&gpio2>;
-		interrupts = <7 IRQ_TYPE_EDGE_RISING>;
+		int-gpios = <&gpio2 7 GPIO_ACTIVE_HIGH>;
 		spi-cpha;
 		spi-cpol;
 		spi-max-frequency = <7142857>;

--- a/drivers/net/ethernet/vertexcom/mse102x.c
+++ b/drivers/net/ethernet/vertexcom/mse102x.c
@@ -512,7 +512,7 @@ static int mse102x_net_open(struct net_device *ndev)
 	int ret;
 
 	if (irqd_get_trigger_type(irq_get_irq_data(ndev->irq)) == IRQ_TYPE_NONE)
-		flags |= IRQ_TYPE_EDGE_RISING;
+		flags |= IRQ_TYPE_LEVEL_HIGH;
 
 	ret = request_threaded_irq(ndev->irq, NULL, mse102x_irq, flags,
 				   ndev->name, mse);

--- a/drivers/net/ethernet/vertexcom/mse102x.c
+++ b/drivers/net/ethernet/vertexcom/mse102x.c
@@ -6,6 +6,7 @@
 
 #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 
+#include <linux/if_vlan.h>
 #include <linux/interrupt.h>
 #include <linux/module.h>
 #include <linux/kernel.h>
@@ -260,7 +261,7 @@ static int mse102x_tx_frame_spi(struct mse102x_net *mse, struct sk_buff *txp,
 }
 
 static int mse102x_rx_frame_spi(struct mse102x_net *mse, u8 *buff,
-				unsigned int frame_len)
+				unsigned int frame_len, bool drop)
 {
 	struct mse102x_net_spi *mses = to_mse102x_spi(mse);
 	struct spi_transfer *xfer = &mses->spi_xfer;
@@ -278,6 +279,9 @@ static int mse102x_rx_frame_spi(struct mse102x_net *mse, u8 *buff,
 		netdev_err(mse->ndev, "%s: spi_sync() failed: %d\n",
 			   __func__, ret);
 		mse->stats.xfer_err++;
+	} else if (drop) {
+		netdev_dbg(mse->ndev, "%s: Drop frame\n", __func__);
+		ret = -EINVAL;
 	} else if (*sof != cpu_to_be16(DET_SOF)) {
 		netdev_dbg(mse->ndev, "%s: SPI start of frame is invalid (0x%04x)\n",
 			   __func__, *sof);
@@ -308,27 +312,33 @@ static void mse102x_rx_pkt_spi(struct mse102x_net *mse)
 	__be16 rx = 0;
 	u16 cmd_resp;
 	u8 *rxpkt;
+	bool drop = false;
 
 	mse102x_tx_cmd_spi(mse, CMD_CTR);
 	if (mse102x_rx_cmd_spi(mse, (u8 *)&rx))
 		return;
 
 	cmd_resp = be16_to_cpu(rx);
-	if ((cmd_resp & CMD_MASK) != CMD_RTS) {
+	if ((cmd_resp & CMD_MASK) == CMD_RTS) {
+		rxlen = cmd_resp & LEN_MASK;
+		if (rxlen < ETH_ZLEN) {
+			net_dbg_ratelimited("%s: Invalid frame length: %d\n",
+					    __func__, rxlen);
+			mse->stats.invalid_len++;
+			drop = true;
+		}
+	} else {
 		net_dbg_ratelimited("%s: Unexpected response (0x%04x)\n",
 				    __func__, cmd_resp);
 		mse->stats.invalid_rts++;
-		return;
+		drop = true;
 	}
 
-	rxlen = cmd_resp & LEN_MASK;
-	if (rxlen < ETH_ZLEN) {
-		net_dbg_ratelimited("%s: Invalid frame length: %d\n", __func__,
-				    rxlen);
-		mse->stats.invalid_len++;
-		return;
-	}
-
+	/* In case of a invalid CMD_RTS, the frame must be consumed anyway.
+	 * So assume the maximum possible frame length.
+	 */
+	if (drop)
+		rxlen = VLAN_ETH_FRAME_LEN;
 
 	rxalign = ALIGN(rxlen + DET_SOF_LEN + DET_DFT_LEN, 4);
 	skb = netdev_alloc_skb_ip_align(mse->ndev, rxalign);
@@ -340,7 +350,7 @@ static void mse102x_rx_pkt_spi(struct mse102x_net *mse)
 	 * They are copied, but ignored.
 	 */
 	rxpkt = skb_put(skb, rxlen) - DET_SOF_LEN;
-	if (mse102x_rx_frame_spi(mse, rxpkt, rxlen)) {
+	if (mse102x_rx_frame_spi(mse, rxpkt, rxlen, drop)) {
 		mse->ndev->stats.rx_errors++;
 		dev_kfree_skb(skb);
 		return;

--- a/drivers/net/ethernet/vertexcom/mse102x.c
+++ b/drivers/net/ethernet/vertexcom/mse102x.c
@@ -335,8 +335,9 @@ static void mse102x_rx_pkt_spi(struct mse102x_net *mse)
 	}
 
 	rxlen = cmd_resp & LEN_MASK;
-	if (!rxlen) {
-		net_dbg_ratelimited("%s: No frame length defined\n", __func__);
+	if (rxlen < ETH_ZLEN) {
+		net_dbg_ratelimited("%s: Invalid frame length: %d\n", __func__,
+				    rxlen);
 		mse->stats.invalid_len++;
 		return;
 	}

--- a/drivers/net/ethernet/vertexcom/mse102x.c
+++ b/drivers/net/ethernet/vertexcom/mse102x.c
@@ -507,6 +507,7 @@ static irqreturn_t mse102x_irq(int irq, void *_mse)
 static int mse102x_net_open(struct net_device *ndev)
 {
 	struct mse102x_net *mse = netdev_priv(ndev);
+	struct mse102x_net_spi *mses = to_mse102x_spi(mse);
 	unsigned long flags = IRQF_ONESHOT;
 	int ret;
 
@@ -525,6 +526,13 @@ static int mse102x_net_open(struct net_device *ndev)
 	netif_start_queue(ndev);
 
 	netif_carrier_on(ndev);
+
+	/* The SPI interrupt can stuck in case of pending packet(s).
+	 * So poll for possible packet(s) to re-arm the interrupt.
+	 */
+	mutex_lock(&mses->lock);
+	mse102x_rx_pkt_spi(mse);
+	mutex_unlock(&mses->lock);
 
 	netif_dbg(mse, ifup, ndev, "network device up\n");
 

--- a/drivers/net/ethernet/vertexcom/mse102x.c
+++ b/drivers/net/ethernet/vertexcom/mse102x.c
@@ -499,8 +499,17 @@ static int mse102x_net_open(struct net_device *ndev)
 	unsigned long flags = IRQF_ONESHOT;
 	int ret;
 
-	if (irqd_get_trigger_type(irq_get_irq_data(ndev->irq)) == IRQ_TYPE_NONE)
+	switch (irqd_get_trigger_type(irq_get_irq_data(ndev->irq))) {
+	case IRQ_TYPE_LEVEL_HIGH:
+	case IRQ_TYPE_LEVEL_LOW:
+		break;
+	case IRQ_TYPE_NONE:
 		flags |= IRQ_TYPE_LEVEL_HIGH;
+		break;
+	default:
+		netdev_warn_once(ndev, "Only IRQ type level recommended, please update your DT.\n");
+		break;
+	}
 
 	ret = request_threaded_irq(ndev->irq, NULL, mse102x_irq, flags,
 				   ndev->name, mse);

--- a/drivers/net/ethernet/vertexcom/mse102x.c
+++ b/drivers/net/ethernet/vertexcom/mse102x.c
@@ -321,7 +321,7 @@ static void mse102x_rx_pkt_spi(struct mse102x_net *mse)
 	cmd_resp = be16_to_cpu(rx);
 	if ((cmd_resp & CMD_MASK) == CMD_RTS) {
 		rxlen = cmd_resp & LEN_MASK;
-		if (rxlen < ETH_ZLEN) {
+		if (rxlen < ETH_ZLEN || rxlen > VLAN_ETH_FRAME_LEN) {
 			net_dbg_ratelimited("%s: Invalid frame length: %d\n",
 					    __func__, rxlen);
 			mse->stats.invalid_len++;

--- a/drivers/net/ethernet/vertexcom/mse102x.c
+++ b/drivers/net/ethernet/vertexcom/mse102x.c
@@ -44,7 +44,6 @@
 
 struct mse102x_stats {
 	u64 xfer_err;
-	u64 invalid_cmd;
 	u64 invalid_ctr;
 	u64 invalid_dft;
 	u64 invalid_len;
@@ -55,7 +54,6 @@ struct mse102x_stats {
 
 static const char mse102x_gstrings_stats[][ETH_GSTRING_LEN] = {
 	"SPI transfer errors",
-	"Invalid command",
 	"Invalid CTR",
 	"Invalid DFT",
 	"Invalid frame length",
@@ -194,7 +192,6 @@ static int mse102x_rx_cmd_spi(struct mse102x_net *mse, u8 *rxb)
 	} else if (*cmd != cpu_to_be16(DET_CMD)) {
 		net_dbg_ratelimited("%s: Unexpected response (0x%04x)\n",
 				    __func__, *cmd);
-		mse->stats.invalid_cmd++;
 		ret = -EIO;
 	} else {
 		memcpy(rxb, trx + 2, 2);


### PR DESCRIPTION
This series fixes the handling of the SPI interrupt in the MSE102x driver. The current solution is consider as a request for comments.

Additional it improves the related debug capabilites by introducing an optional DT property to use the interrupt line as GPIO (currently not intended for upstream).