### PR TITLE
arm64: dts: imx93-charge-control-y: add missing model and small fixes

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx93-charge-control-y.dts
+++ b/arch/arm64/boot/dts/freescale/imx93-charge-control-y.dts
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 /*
  * Copyright (C) 2025 chargebyte GmbH
- * Author: Martin Lukas <martin.lukas@chargebyte.com>
  */
 
- /dts-v1/;
+/dts-v1/;
 
 #include <dt-bindings/interrupt-controller/irq.h>
 #include "imx93-phycore-som.dtsi"
 
 / {
+	model = "chargebyte Charge Control Y";
 	compatible = "chargebyte,imx93-charge-control-y", "phytec,imx93-phycore-som", "fsl,imx93";
 
 	chosen {
@@ -63,7 +63,7 @@
 	status = "okay";
 };
 
-/* Safety controller*/
+/* Safety Controller */
 &lpuart2 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_uart2>;
@@ -190,33 +190,33 @@
 	/*  */
 	pinctrl_eqos: eqosgrp {
 		fsl,pins = <
-			MX93_PAD_ENET1_TD2__CCM_ENET_QOS_CLOCK_GENERATE_REF_CLK	0x4000050e
-			MX93_PAD_ENET1_RD0__ENET_QOS_RGMII_RD0					0x57e
-			MX93_PAD_ENET1_RD1__ENET_QOS_RGMII_RD1					0x57e
-			MX93_PAD_ENET1_TD0__ENET_QOS_RGMII_TD0					0x50e
-			MX93_PAD_ENET1_TD1__ENET_QOS_RGMII_TD1					0x50e
+			MX93_PAD_ENET1_TD2__CCM_ENET_QOS_CLOCK_GENERATE_REF_CLK		0x4000050e
+			MX93_PAD_ENET1_RD0__ENET_QOS_RGMII_RD0				0x57e
+			MX93_PAD_ENET1_RD1__ENET_QOS_RGMII_RD1				0x57e
+			MX93_PAD_ENET1_TD0__ENET_QOS_RGMII_TD0				0x50e
+			MX93_PAD_ENET1_TD1__ENET_QOS_RGMII_TD1				0x50e
 			MX93_PAD_ENET1_RX_CTL__ENET_QOS_RGMII_RX_CTL			0x57e
 			MX93_PAD_ENET1_TX_CTL__ENET_QOS_RGMII_TX_CTL			0x50e
-			MX93_PAD_ENET1_RXC__ENET_QOS_RX_ER						0x57e
+			MX93_PAD_ENET1_RXC__ENET_QOS_RX_ER				0x57e
 		>;
 	};
 
 	/* Pinctrl SD */
 	pinctrl_reg_usdhc2_vmmc: regusdhc2vmmcgrp {
 		fsl,pins = <
-			MX93_PAD_SD2_RESET_B__GPIO3_IO07		0x31e // X_SD2_nRESET
+			MX93_PAD_SD2_RESET_B__GPIO3_IO07	0x31e // X_SD2_nRESET
 		>;
 	};
 
 	/* need to config the SION for data and cmd pad, refer to ERR052021 */
 	pinctrl_usdhc2_default: usdhc2grp {
 		fsl,pins = <
-			MX93_PAD_SD2_CLK__USDHC2_CLK			0x179e
-			MX93_PAD_SD2_CMD__USDHC2_CMD			0x4000139e
-			MX93_PAD_SD2_DATA0__USDHC2_DATA0		0x4000138e
-			MX93_PAD_SD2_DATA1__USDHC2_DATA1		0x4000138e
-			MX93_PAD_SD2_DATA2__USDHC2_DATA2		0x4000138e
-			MX93_PAD_SD2_DATA3__USDHC2_DATA3		0x4000139e
+			MX93_PAD_SD2_CLK__USDHC2_CLK		0x179e
+			MX93_PAD_SD2_CMD__USDHC2_CMD		0x4000139e
+			MX93_PAD_SD2_DATA0__USDHC2_DATA0	0x4000138e
+			MX93_PAD_SD2_DATA1__USDHC2_DATA1	0x4000138e
+			MX93_PAD_SD2_DATA2__USDHC2_DATA2	0x4000138e
+			MX93_PAD_SD2_DATA3__USDHC2_DATA3	0x4000139e
 			MX93_PAD_SD2_VSELECT__USDHC2_VSELECT	0x51e
 		>;
 	};
@@ -260,7 +260,7 @@
 		>;
 	};
 
-	/* Pinctrl Safety controller */
+	/* Pinctrl Safety Controller */
 	pinctrl_uart2: uart2grp {
 		fsl,pins = <
 			MX93_PAD_UART2_RXD__LPUART2_RX		0x31e // drive strength: X4, slew rate: slightly fast, pull up
@@ -278,8 +278,8 @@
 
 	pinctrl_flexcan1: flexcan1grp {
 		fsl,pins = <
-			MX93_PAD_PDM_BIT_STREAM0__CAN1_RX		0x139e
-			MX93_PAD_PDM_CLK__CAN1_TX				0x1382
+			MX93_PAD_PDM_BIT_STREAM0__CAN1_RX	0x139e
+			MX93_PAD_PDM_CLK__CAN1_TX		0x1382
 		>;
 	};
 };


### PR DESCRIPTION
The toplevel model property is missing but important for user-space applications, so add it.

While at, fix various small whitespace and other nit-picks to align with other chargebyte products.