### PR TITLE
Adapt default-intensity to mainline implementation

### DIFF
--- a/arch/arm64/boot/dts/freescale/imx93-charge-som-ac-pb.dtso
+++ b/arch/arm64/boot/dts/freescale/imx93-charge-som-ac-pb.dtso
@@ -51,7 +51,6 @@
 		color = <LED_COLOR_ID_RGB>;
 		function = LED_FUNCTION_STATUS;
 		leds = <&led0>, <&led1>, <&led2>, <&led3>;
-		default-intensity = <0>, <0>, <0>, <255>;
 		linux,default-trigger = "timer";
 	};
 };
@@ -296,24 +295,28 @@
 			reg = <0>;
 			color = <LED_COLOR_ID_RED>;
 			function = LED_FUNCTION_STATUS;
+			default-intensity = <0>;
 		};
 
 		led1: led@1 {
 			reg = <1>;
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_STATUS;
+			default-intensity = <0>;
 		};
 
 		led2: led@2 {
 			reg = <2>;
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_STATUS;
+			default-intensity = <0>;
 		};
 
 		led3: led@3 {
 			reg = <3>;
 			color = <LED_COLOR_ID_WHITE>;
 			function = LED_FUNCTION_STATUS;
+			default-intensity = <255>;
 		};
 	};
 };

--- a/drivers/leds/rgb/leds-group-multicolor.c
+++ b/drivers/leds/rgb/leds-group-multicolor.c
@@ -107,23 +107,15 @@ static int leds_gmc_probe(struct platform_device *pdev)
 
 	for (i = 0; i < count; i++) {
 		struct led_classdev *led_cdev = priv->monochromatics[i];
-		u32 intensity;
 
 		subled[i].color_index = led_cdev->color;
 
-		ret = of_property_read_u32_index(pdev->dev.of_node, "default-intensity",
-						 i, &intensity);
+		ret = fwnode_property_read_u32(led_cdev->dev->fwnode, "default-intensity",
+					       &subled[i].intensity);
 		if (ret) {
-			if (ret != -EINVAL && ret != -ENOSYS) {
-				return dev_err_probe(dev, ret, "Unable to get default-intensity[%d]\n",
-				       i);
-			}
 			subled[i].intensity = max_brightness;
-		} else if (intensity > max_brightness) {
-			return dev_err_probe(dev, -EINVAL, "default-intensity[%d] is invalid\n",
-					     i);
-		} else {
-			subled[i].intensity = intensity;
+		} else if (subled[i].intensity > max_brightness) {
+			subled[i].intensity = max_brightness;
 		}
 
 		dev_dbg(dev, "subled[%d]: color_index: %u, intensity: %u\n",


### PR DESCRIPTION
Some weeks after our downstream implementation Pengutronix implemented
the default-intensity property in a different way:

https://lore.kernel.org/all/20260605-multicolor-default-v2-0-ed07271df6b0@pengutronix.de/

Adapt leds-group-multicolor to this approach, but keep in mind that
the implementation still needs to be backward compatible. So in case the
property is missing the intensity should be max brightness.